### PR TITLE
[skip ci] GitHub Actions の設定見直し

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -4,16 +4,20 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-pull-request:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.head_ref }}
+          persist-credentials: false
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: "npm"


### PR DESCRIPTION
## 概要
- Pull Request チェック用 workflow のセキュリティ設定を見直し
- pinact を使って GitHub Actions の参照を固定
- workflow token の権限と checkout 時の認証情報の扱いを制限

## 修正理由
Public repositoryなので GitHub Actions 経由の supply-chain risk や token exposure risk をできるだけ小さくした

[zizmor](https://github.com/zizmorcore/zizmor) で 以下の指摘が出ていたのでそれぞれ対応しました。
- unpinned action references
- broad default permissions
- checkout credential persistence

## 検証
- [x] pinact run --check .github/workflows/check-pull-request.yml
- [x] zizmor .github/workflows/check-pull-request.yml